### PR TITLE
fix: Unity constantly logs warning about package.json missing meta file

### DIFF
--- a/Assets/UniStandaloneFileBrowser/package.json.meta
+++ b/Assets/UniStandaloneFileBrowser/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 01b2b5d86e4168940a7f68de8f36f7d2
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
When using from a package registry such as OpenUPM, the package content is immutable.
The file was named package-lock.json, so Unity would constantly complain about the package.json.meta file missing.
This PR just renames the file and fixes the issue.